### PR TITLE
Static Serving Error

### DIFF
--- a/internal/helpers/setup_handlers.go
+++ b/internal/helpers/setup_handlers.go
@@ -2,11 +2,12 @@ package helpers
 
 import (
 	"github.com/gofiber/fiber/v3"
+	"github.com/gofiber/fiber/v3/middleware/static"
 	"github.com/manitvig/gotham-starter-app/internal/handlers"
 )
 
 func SetupHandlers(app *fiber.App) {
-	app.Static("/", "./public/")
+	app.Get("/public", static.New("/public/"))
 	
 	app.Get("/", handlers.IndexPage)
 	app.Post("/increment", handlers.Increment)

--- a/templates/views/index.templ
+++ b/templates/views/index.templ
@@ -9,7 +9,7 @@ templ Index(count uint) {
 			<title>Gotham Quickstart</title>
 			<meta charset="UTF-8" />
 			<meta name="viewport" content="width=device-width, initial-scale=1" />
-			<script src="/bundle.js"></script>
+			<script src="/public/bundle.js"></script>
 		</head>
 		<body class="bg-gray-300">
 			<div class="w-full h-[90vh] flex flex-col justify-center items-center space-y-2.5">


### PR DESCRIPTION
In the setup_handlers file fiber does not support a app.Static function. The correct way to do this is with a `app.Get` with a static.New handler. This allows the project to build successfully after running `bunx create-gotham-app`